### PR TITLE
13 Task. Resize widget to 2x2

### DIFF
--- a/src/main/java/koval/mobile/myfit/gui/ios/downMenuPages/HomePage.java
+++ b/src/main/java/koval/mobile/myfit/gui/ios/downMenuPages/HomePage.java
@@ -29,6 +29,11 @@ public class HomePage extends HomePageBase {
     }
 
     @Override
+    public boolean isPageOpened(Long timeout) {
+        throw new NotImplementedException();
+    }
+
+    @Override
     public WelcomePageBase signOut() {
         throw new NotImplementedException();
     }

--- a/src/main/java/koval/mobile/myfitnesspal/gui/IMyInterface.java
+++ b/src/main/java/koval/mobile/myfitnesspal/gui/IMyInterface.java
@@ -2,8 +2,11 @@ package koval.mobile.myfitnesspal.gui;
 
 import com.qaprosoft.carina.core.foundation.IAbstractTest;
 import com.zebrunner.carina.utils.mobile.IMobileUtils;
+import koval.mobile.myfitnesspal.service.AdbService;
 import koval.mobile.myfitnesspal.utils.IConstantUtils;
 
 public interface IMyInterface extends IConstantUtils, IMobileUtils, IAbstractTest {
+
+    AdbService adbService = new AdbService();
 
 }

--- a/src/main/java/koval/mobile/myfitnesspal/gui/MyAbstractPage.java
+++ b/src/main/java/koval/mobile/myfitnesspal/gui/MyAbstractPage.java
@@ -9,7 +9,6 @@ import org.slf4j.LoggerFactory;
 
 
 import java.lang.invoke.MethodHandles;
-import java.util.Random;
 
 
 public abstract class MyAbstractPage extends AbstractPage implements IMyInterface {
@@ -30,13 +29,32 @@ public abstract class MyAbstractPage extends AbstractPage implements IMyInterfac
     }
 
     public void hideKeyboard() {
-        getDriver().navigate().back();
+        pressKey(BACK);
     }
 
+    public void pressKey(int keyCodeValue) {
+        getDevice(getDriver()).pressKey(keyCodeValue);
+    }
 
     public void closeTimestampsPopUpIfPresent() {
         itemByContent.format(NO_THANKS_ANSWER.toUpperCase()).clickIfPresent(TIMEOUT_FIVE);
     }
 
+
+    public int getCenterX(ExtendedWebElement extendedWebElement) {
+
+        int leftX = extendedWebElement.getLocation().getX();
+        int rightX = extendedWebElement.getSize().getWidth();
+
+        return (leftX + (leftX + rightX)) / 2;
+    }
+
+    public int getCenterY(ExtendedWebElement extendedWebElement) {
+
+        int upperY = extendedWebElement.getLocation().getY();
+        int lowerY = extendedWebElement.getSize().getHeight();
+
+        return (upperY + (upperY + lowerY)) / 2;
+    }
 
 }

--- a/src/main/java/koval/mobile/myfitnesspal/gui/android/downMenuPages/DashboardPage.java
+++ b/src/main/java/koval/mobile/myfitnesspal/gui/android/downMenuPages/DashboardPage.java
@@ -16,7 +16,6 @@ import org.openqa.selenium.support.FindBy;
 @DeviceType(pageType = DeviceType.Type.ANDROID_PHONE, parentClass = DashboardPageBase.class)
 public class DashboardPage extends DashboardPageBase {
 
-
     @FindBy(id = "com.myfitnesspal.android:id/bottomNavigationBar")
     private DownMenuModal downMenuModal;
 
@@ -30,7 +29,6 @@ public class DashboardPage extends DashboardPageBase {
     public DashboardPage(WebDriver driver) {
         super(driver);
     }
-
 
     @Override
     public boolean isPageOpened() {

--- a/src/main/java/koval/mobile/myfitnesspal/gui/android/downMenuPages/DiaryPage.java
+++ b/src/main/java/koval/mobile/myfitnesspal/gui/android/downMenuPages/DiaryPage.java
@@ -112,7 +112,7 @@ public class DiaryPage extends DiaryPageBase {
         ExtendedWebElement testEl = addFoodButton.format(meals.getMeal());
         swipe(testEl, Direction.UP, TWENTY_COUNT, MEDIUM_SPEED);
 
-        if (meals.getMeal().equals("Snacks")) {
+        if (meals.getMeal().equals(SNACKS)) {
             ExtendedWebElement snackTitleByText = itemByText.format(CONNECT_A_STEP_TRACKER);
             swipe(snackTitleByText, Direction.UP, TWENTY_COUNT, MEDIUM_SPEED);
         }
@@ -128,7 +128,7 @@ public class DiaryPage extends DiaryPageBase {
 
         boolean isFoodAddedToMeal;
 
-        if (meals.getMeal().equals("Snacks")) {
+        if (meals.getMeal().equals(SNACKS)) {
             ExtendedWebElement snackTitleByText = itemByText.format(CONNECT_A_STEP_TRACKER);
             swipe(snackTitleByText, Direction.DOWN, TWENTY_COUNT, MEDIUM_SPEED);
             isFoodAddedToMeal = foodTitle.format(meals.getMeal(), food).isElementPresent(TIMEOUT_TEN);

--- a/src/main/java/koval/mobile/myfitnesspal/gui/android/downMenuPages/DiaryPage.java
+++ b/src/main/java/koval/mobile/myfitnesspal/gui/android/downMenuPages/DiaryPage.java
@@ -111,6 +111,12 @@ public class DiaryPage extends DiaryPageBase {
 
         ExtendedWebElement testEl = addFoodButton.format(meals.getMeal());
         swipe(testEl, Direction.UP, TWENTY_COUNT, MEDIUM_SPEED);
+
+        if (meals.getMeal().equals("Snacks")) {
+            ExtendedWebElement snackTitleByText = itemByText.format("Connect a step tracker");
+            swipe(snackTitleByText, Direction.UP, TWENTY_COUNT, MEDIUM_SPEED);
+        }
+
         addFoodButton.format(meals.getMeal()).click();
 
         return initPage(getDriver(), SearchFoodPageBase.class);
@@ -120,15 +126,21 @@ public class DiaryPage extends DiaryPageBase {
     @Override
     public boolean isFoodAddedToMeal(String food, Meals meals) {
 
-        ExtendedWebElement mealByText = mealTitleByText.format(meals.getMeal());
-        swipe(mealByText, diaryRecyclerViewContainer, Direction.DOWN, TWENTY_COUNT, MEDIUM_SPEED);
+        boolean isFoodAddedToMeal;
 
         if (meals.getMeal().equals("Snacks")) {
-            ExtendedWebElement snackTitleByText = itemByText.format(EXERCISE_STRING);
-            swipe(snackTitleByText, Direction.UP, TWENTY_COUNT, MEDIUM_SPEED);
+            ExtendedWebElement snackTitleByText = itemByText.format("Connect a step tracker");
+            swipe(snackTitleByText, Direction.DOWN, TWENTY_COUNT, MEDIUM_SPEED);
+            isFoodAddedToMeal = foodTitle.format(meals.getMeal(), food).isElementPresent(TIMEOUT_TEN);
+        }
+        else {
+            ExtendedWebElement mealByText = mealTitleByText.format(meals.getMeal());
+            swipe(mealByText, Direction.DOWN, TWENTY_COUNT, MEDIUM_SPEED);
+            isFoodAddedToMeal = foodTitle.format(meals.getMeal(), food).isElementPresent(TIMEOUT_TEN);
         }
 
-        return foodTitle.format(meals.getMeal(), food).isElementPresent(TIMEOUT_TEN);
+
+        return isFoodAddedToMeal;
     }
 
 

--- a/src/main/java/koval/mobile/myfitnesspal/gui/android/downMenuPages/DiaryPage.java
+++ b/src/main/java/koval/mobile/myfitnesspal/gui/android/downMenuPages/DiaryPage.java
@@ -113,7 +113,7 @@ public class DiaryPage extends DiaryPageBase {
         swipe(testEl, Direction.UP, TWENTY_COUNT, MEDIUM_SPEED);
 
         if (meals.getMeal().equals("Snacks")) {
-            ExtendedWebElement snackTitleByText = itemByText.format("Connect a step tracker");
+            ExtendedWebElement snackTitleByText = itemByText.format(CONNECT_A_STEP_TRACKER);
             swipe(snackTitleByText, Direction.UP, TWENTY_COUNT, MEDIUM_SPEED);
         }
 
@@ -129,7 +129,7 @@ public class DiaryPage extends DiaryPageBase {
         boolean isFoodAddedToMeal;
 
         if (meals.getMeal().equals("Snacks")) {
-            ExtendedWebElement snackTitleByText = itemByText.format("Connect a step tracker");
+            ExtendedWebElement snackTitleByText = itemByText.format(CONNECT_A_STEP_TRACKER);
             swipe(snackTitleByText, Direction.DOWN, TWENTY_COUNT, MEDIUM_SPEED);
             isFoodAddedToMeal = foodTitle.format(meals.getMeal(), food).isElementPresent(TIMEOUT_TEN);
         }

--- a/src/main/java/koval/mobile/myfitnesspal/gui/android/loginPages/LogInPage.java
+++ b/src/main/java/koval/mobile/myfitnesspal/gui/android/loginPages/LogInPage.java
@@ -82,7 +82,7 @@ public class LogInPage extends LogInPageBase {
         while (exitTutorialButton.isElementPresent(TIMEOUT_TEN) && attemp > 0) {
             exitTutorialButton.click(TIMEOUT_TEN);
 
-            LOGGER.info("[ LOGIN PAGE ] Attempt: {} for clicking on exit tutorial button", attemp);
+            LOGGER.info("[ DASHBOARD PAGE ] Attempt left: {} for clicking on exit tutorial button", attemp);
             attemp--;
         }
 

--- a/src/main/java/koval/mobile/myfitnesspal/gui/android/phoneInterface/PhoneHomePage.java
+++ b/src/main/java/koval/mobile/myfitnesspal/gui/android/phoneInterface/PhoneHomePage.java
@@ -1,0 +1,145 @@
+package koval.mobile.myfitnesspal.gui.android.phoneInterface;
+
+
+import com.qaprosoft.carina.core.foundation.webdriver.decorator.ExtendedWebElement;
+import com.qaprosoft.carina.core.gui.AbstractPage;
+import com.zebrunner.carina.utils.factory.DeviceType;
+import koval.mobile.myfitnesspal.gui.common.phoneInterface.PhoneHomePageBase;
+import koval.mobile.myfitnesspal.gui.common.phoneInterface.PhoneWidgetPageBase;
+import koval.mobile.myfitnesspal.gui.common.searchFood.SearchFoodPageBase;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+
+
+@DeviceType(pageType = DeviceType.Type.ANDROID_PHONE, parentClass = PhoneHomePageBase.class)
+public class PhoneHomePage extends PhoneHomePageBase {
+
+    @FindBy(xpath = "//*[@text='%s']")
+    private ExtendedWebElement itemByText;
+
+    @FindBy(xpath = "//*[@content-desc='%s']")
+    private ExtendedWebElement itemByContent;
+
+    @FindBy(id = "com.myfitnesspal.android:id/layoutWidgetCalories")
+    private ExtendedWebElement fitnessPalWidgetItem;
+
+    @FindBy(id = "com.google.android.apps.nexuslauncher:id/widget_resize_frame")
+    private ExtendedWebElement resizeWidgetFrame;
+
+    @FindBy(id = "com.google.android.apps.nexuslauncher:id/widget_resize_right_handle")
+    private ExtendedWebElement rightResizeHandle;
+
+    @FindBy(id = "com.myfitnesspal.android:id/imageWidgetCaloriesSearch")
+    private ExtendedWebElement widgetCaloriesSearchImage;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+
+    public PhoneHomePage(WebDriver driver) {
+        super(driver);
+    }
+
+
+    public AbstractPage holdElement(ExtendedWebElement extendedWebElement, Class<? extends AbstractPage> className) {
+
+        int centerX = getCenterX(extendedWebElement);
+        int centerY = getCenterY(extendedWebElement);
+
+        adbService.holdElementByCoordinates(centerX, centerY);
+
+        return initPage(getDriver(), className);
+    }
+
+    public AbstractPage tapElement(ExtendedWebElement extendedWebElement, Class<? extends AbstractPage> className) {
+
+        extendedWebElement.click();
+
+        return initPage(getDriver(), className);
+    }
+
+    @Override
+    public PhoneHomePageBase holdPhoneDesktop() {
+
+        return (PhoneHomePageBase) holdElement(itemByContent.format(HOME_STRING), PhoneHomePageBase.class);
+    }
+
+
+    @Override
+    public PhoneHomePageBase holdWidget(ExtendedWebElement widget) {
+
+        //itemByContent.format(widgetName)
+        return (PhoneHomePageBase) holdElement(widget, PhoneHomePageBase.class);
+    }
+
+
+    @Override
+    public boolean isSearchButtonPresent(int timeout) {
+
+        waitUntil(ExpectedConditions.invisibilityOfElementLocated(itemByText.format(LOADING).getBy()), TIMEOUT_TWENTY);
+
+        return widgetCaloriesSearchImage.isElementPresent(timeout);
+    }
+
+
+    @Override
+    public boolean isFitnessPalWidgetPresent(int timeout) {
+        pressKey(BACK);
+        return fitnessPalWidgetItem.isElementPresent(timeout);
+    }
+
+
+    @Override
+    public SearchFoodPageBase pressSearchButton() {
+
+        return (SearchFoodPageBase) tapElement(widgetCaloriesSearchImage, SearchFoodPageBase.class);
+    }
+
+
+    @Override
+    public PhoneWidgetPageBase tapWidgetButton() {
+        return (PhoneWidgetPageBase) tapElement(itemByText.format(WIDGETS_STRING), PhoneWidgetPageBase.class);
+
+    }
+
+
+    @Override
+    public PhoneHomePageBase deleteWidget(String widgetName) {
+
+        holdWidget(itemByContent.format(widgetName));
+
+        while (resizeWidgetFrame.isElementPresent(TIMEOUT_FIFTEEN)) {
+            int centerX = getCenterX(resizeWidgetFrame);
+            int centerY = getCenterY(resizeWidgetFrame);
+
+            int desiredY = centerY - SCREEN_PHYSICAL_DENSITY;
+
+            swipe(centerX, centerY, centerX, desiredY, LOW_SPEED);
+        }
+
+        return initPage(getDriver(), PhoneHomePageBase.class);
+    }
+
+    @Override
+    public PhoneHomePageBase resizeWidgetByX(int sizeValue) {
+
+        holdWidget(fitnessPalWidgetItem);
+        int centerX = getCenterX(rightResizeHandle);
+        int centerY = getCenterY(rightResizeHandle);
+
+        LOGGER.info("Screen Physical Density is: {}", SCREEN_PHYSICAL_DENSITY);
+
+        int desiredX = sizeValue * SCREEN_PHYSICAL_DENSITY;
+
+        swipe(centerX, centerY, desiredX, centerY, MEDIUM_SPEED);
+
+        pressKey(BACK);
+
+        return initPage(getDriver(), PhoneHomePageBase.class);
+    }
+
+}

--- a/src/main/java/koval/mobile/myfitnesspal/gui/android/phoneInterface/PhoneHomePage.java
+++ b/src/main/java/koval/mobile/myfitnesspal/gui/android/phoneInterface/PhoneHomePage.java
@@ -111,34 +111,38 @@ public class PhoneHomePage extends PhoneHomePageBase {
 
         holdWidget(itemByContent.format(widgetName));
 
-        while (resizeWidgetFrame.isElementPresent(TIMEOUT_FIFTEEN)) {
-            int centerX = getCenterX(resizeWidgetFrame);
-            int centerY = getCenterY(resizeWidgetFrame);
 
-            int desiredY = centerY - SCREEN_PHYSICAL_DENSITY;
+        int attemp = 3;
+            while (resizeWidgetFrame.isElementPresent(TIMEOUT_FIFTEEN)  && attemp > 0 ) {
+                int centerX = getCenterX(resizeWidgetFrame);
+                int centerY = getCenterY(resizeWidgetFrame);
 
-            swipe(centerX, centerY, centerX, desiredY, LOW_SPEED);
+                int desiredY = centerY - SCREEN_PHYSICAL_DENSITY;
+
+                swipe(centerX, centerY, centerX, desiredY, LOW_SPEED);
+
+                attemp--;
+            }
+
+            return initPage(getDriver(), PhoneHomePageBase.class);
         }
 
-        return initPage(getDriver(), PhoneHomePageBase.class);
+        @Override
+        public PhoneHomePageBase resizeWidgetByX ( int sizeValue){
+
+            holdWidget(fitnessPalWidgetItem);
+            int centerX = getCenterX(rightResizeHandle);
+            int centerY = getCenterY(rightResizeHandle);
+
+            LOGGER.info("Screen Physical Density is: {}", SCREEN_PHYSICAL_DENSITY);
+
+            int desiredX = sizeValue * SCREEN_PHYSICAL_DENSITY;
+
+            swipe(centerX, centerY, desiredX, centerY, MEDIUM_SPEED);
+
+            pressKey(BACK);
+
+            return initPage(getDriver(), PhoneHomePageBase.class);
+        }
+
     }
-
-    @Override
-    public PhoneHomePageBase resizeWidgetByX(int sizeValue) {
-
-        holdWidget(fitnessPalWidgetItem);
-        int centerX = getCenterX(rightResizeHandle);
-        int centerY = getCenterY(rightResizeHandle);
-
-        LOGGER.info("Screen Physical Density is: {}", SCREEN_PHYSICAL_DENSITY);
-
-        int desiredX = sizeValue * SCREEN_PHYSICAL_DENSITY;
-
-        swipe(centerX, centerY, desiredX, centerY, MEDIUM_SPEED);
-
-        pressKey(BACK);
-
-        return initPage(getDriver(), PhoneHomePageBase.class);
-    }
-
-}

--- a/src/main/java/koval/mobile/myfitnesspal/gui/android/phoneInterface/PhoneHomePage.java
+++ b/src/main/java/koval/mobile/myfitnesspal/gui/android/phoneInterface/PhoneHomePage.java
@@ -72,7 +72,6 @@ public class PhoneHomePage extends PhoneHomePageBase {
     @Override
     public PhoneHomePageBase holdWidget(ExtendedWebElement widget) {
 
-        //itemByContent.format(widgetName)
         return (PhoneHomePageBase) holdElement(widget, PhoneHomePageBase.class);
     }
 

--- a/src/main/java/koval/mobile/myfitnesspal/gui/android/phoneInterface/PhoneHomePage.java
+++ b/src/main/java/koval/mobile/myfitnesspal/gui/android/phoneInterface/PhoneHomePage.java
@@ -111,38 +111,37 @@ public class PhoneHomePage extends PhoneHomePageBase {
 
         holdWidget(itemByContent.format(widgetName));
 
-
         int attemp = 3;
-            while (resizeWidgetFrame.isElementPresent(TIMEOUT_FIFTEEN)  && attemp > 0 ) {
-                int centerX = getCenterX(resizeWidgetFrame);
-                int centerY = getCenterY(resizeWidgetFrame);
+        while (resizeWidgetFrame.isElementPresent(TIMEOUT_FIFTEEN) && attemp > 0) {
+            int centerX = getCenterX(resizeWidgetFrame);
+            int centerY = getCenterY(resizeWidgetFrame);
 
-                int desiredY = centerY - SCREEN_PHYSICAL_DENSITY;
+            int desiredY = centerY - SCREEN_PHYSICAL_DENSITY;
 
-                swipe(centerX, centerY, centerX, desiredY, LOW_SPEED);
+            swipe(centerX, centerY, centerX, desiredY, LOW_SPEED);
 
-                attemp--;
-            }
-
-            return initPage(getDriver(), PhoneHomePageBase.class);
+            attemp--;
         }
 
-        @Override
-        public PhoneHomePageBase resizeWidgetByX ( int sizeValue){
-
-            holdWidget(fitnessPalWidgetItem);
-            int centerX = getCenterX(rightResizeHandle);
-            int centerY = getCenterY(rightResizeHandle);
-
-            LOGGER.info("Screen Physical Density is: {}", SCREEN_PHYSICAL_DENSITY);
-
-            int desiredX = sizeValue * SCREEN_PHYSICAL_DENSITY;
-
-            swipe(centerX, centerY, desiredX, centerY, MEDIUM_SPEED);
-
-            pressKey(BACK);
-
-            return initPage(getDriver(), PhoneHomePageBase.class);
-        }
-
+        return initPage(getDriver(), PhoneHomePageBase.class);
     }
+
+    @Override
+    public PhoneHomePageBase resizeWidgetByX(int sizeValue) {
+
+        holdWidget(fitnessPalWidgetItem);
+        int centerX = getCenterX(rightResizeHandle);
+        int centerY = getCenterY(rightResizeHandle);
+
+        LOGGER.info("Screen Physical Density is: {}", SCREEN_PHYSICAL_DENSITY);
+
+        int desiredX = sizeValue * SCREEN_PHYSICAL_DENSITY;
+
+        swipe(centerX, centerY, desiredX, centerY, MEDIUM_SPEED);
+
+        pressKey(BACK);
+
+        return initPage(getDriver(), PhoneHomePageBase.class);
+    }
+
+}

--- a/src/main/java/koval/mobile/myfitnesspal/gui/android/phoneInterface/PhoneWidgetPage.java
+++ b/src/main/java/koval/mobile/myfitnesspal/gui/android/phoneInterface/PhoneWidgetPage.java
@@ -1,0 +1,67 @@
+package koval.mobile.myfitnesspal.gui.android.phoneInterface;
+
+
+import com.qaprosoft.carina.core.foundation.webdriver.decorator.ExtendedWebElement;
+import com.zebrunner.carina.utils.factory.DeviceType;
+import koval.mobile.myfitnesspal.gui.common.phoneInterface.PhoneHomePageBase;
+import koval.mobile.myfitnesspal.gui.common.phoneInterface.PhoneWidgetPageBase;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.FindBy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+
+
+@DeviceType(pageType = DeviceType.Type.ANDROID_PHONE, parentClass = PhoneWidgetPageBase.class)
+public class PhoneWidgetPage extends PhoneWidgetPageBase {
+
+    @FindBy(xpath = "//*[@text='%s']")
+    private ExtendedWebElement itemByText;
+
+    @FindBy(id = "com.google.android.apps.nexuslauncher:id/widgets_search_bar_edit_text")
+    private ExtendedWebElement searchWidgetField;
+
+    @FindBy(xpath = "//*[@resource-id='com.google.android.apps.nexuslauncher:id/app_title' and @text='%s']")
+    private ExtendedWebElement appTitle;
+
+    @FindBy(xpath = "//*[@text='%s']/parent::*/*[@resource-id='com.google.android.apps.nexuslauncher:id/widget_preview_container']")
+    private ExtendedWebElement widgetContainer;
+
+    public PhoneWidgetPage(WebDriver driver) {
+        super(driver);
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+
+    @Override
+    public boolean isPageOpened(int timeout) {
+        return itemByText.format(WIDGETS_STRING).isElementPresent(timeout);
+    }
+
+    @Override
+    public boolean isPageOpened() {
+        return isPageOpened(TIMEOUT_FIFTEEN);
+    }
+
+    @Override
+    public PhoneHomePageBase addWidgetToDesktop(String appName, String widgetName) {
+
+        searchWidgetField.type(appName);
+
+        appTitle.format(appName).click();
+
+        int centerX = getCenterX(widgetContainer.format(widgetName));
+
+        int centerY = getCenterY(widgetContainer.format(widgetName));
+        int upperY = (centerY - widgetContainer.format(widgetName).getLocation().getY()) / 2;
+        int desiredY = centerY - upperY;
+
+        adbService.holdElementByCoordinates(centerX, desiredY);
+
+        return initPage(getDriver(), PhoneHomePageBase.class);
+    }
+
+
+}

--- a/src/main/java/koval/mobile/myfitnesspal/gui/android/searchFood/SearchFoodPage.java
+++ b/src/main/java/koval/mobile/myfitnesspal/gui/android/searchFood/SearchFoodPage.java
@@ -65,6 +65,11 @@ public class SearchFoodPage extends SearchFoodPageBase {
 
 
     @Override
+    public boolean isPageOpened() {
+        return searchFoodField.isElementPresent(TIMEOUT_TEN);
+    }
+
+    @Override
     public SearchFoodPageBase changeMealByName(Meals meals) {
 
         if (!selectMealText.getText().equals(meals.getMeal())) {

--- a/src/main/java/koval/mobile/myfitnesspal/gui/common/downMenuPages/DashboardPageBase.java
+++ b/src/main/java/koval/mobile/myfitnesspal/gui/common/downMenuPages/DashboardPageBase.java
@@ -13,7 +13,6 @@ public abstract class DashboardPageBase extends MyAbstractPage {
         super(driver);
     }
 
-
     public abstract AbstractPage openPageFromDownMenuByName(DownMenuElement downMenuElement);
 
     public abstract boolean isUserPremium();

--- a/src/main/java/koval/mobile/myfitnesspal/gui/common/phoneInterface/PhoneHomePageBase.java
+++ b/src/main/java/koval/mobile/myfitnesspal/gui/common/phoneInterface/PhoneHomePageBase.java
@@ -1,0 +1,33 @@
+package koval.mobile.myfitnesspal.gui.common.phoneInterface;
+
+import com.qaprosoft.carina.core.foundation.webdriver.decorator.ExtendedWebElement;
+import com.qaprosoft.carina.core.gui.AbstractPage;
+import koval.mobile.myfitnesspal.gui.MyAbstractPage;
+import koval.mobile.myfitnesspal.gui.common.searchFood.SearchFoodPageBase;
+import org.openqa.selenium.WebDriver;
+
+
+public abstract class PhoneHomePageBase extends MyAbstractPage {
+
+    public PhoneHomePageBase(WebDriver driver) {
+        super(driver);
+    }
+
+
+    public abstract AbstractPage holdPhoneDesktop();
+
+
+    public abstract PhoneHomePageBase holdWidget(ExtendedWebElement widget);
+
+    public abstract boolean isSearchButtonPresent(int timeout);
+
+    public abstract boolean isFitnessPalWidgetPresent(int timeout);
+
+    public abstract SearchFoodPageBase pressSearchButton();
+
+    public abstract PhoneWidgetPageBase tapWidgetButton();
+
+    public abstract PhoneHomePageBase deleteWidget(String widgetName);
+
+    public abstract PhoneHomePageBase resizeWidgetByX(int sizeValue);
+}

--- a/src/main/java/koval/mobile/myfitnesspal/gui/common/phoneInterface/PhoneWidgetPageBase.java
+++ b/src/main/java/koval/mobile/myfitnesspal/gui/common/phoneInterface/PhoneWidgetPageBase.java
@@ -1,0 +1,16 @@
+package koval.mobile.myfitnesspal.gui.common.phoneInterface;
+
+import koval.mobile.myfitnesspal.gui.MyAbstractPage;
+import org.openqa.selenium.WebDriver;
+
+
+public abstract class PhoneWidgetPageBase extends MyAbstractPage {
+
+    public PhoneWidgetPageBase(WebDriver driver) {
+        super(driver);
+    }
+
+    public abstract boolean isPageOpened(int timeout);
+
+    public abstract PhoneHomePageBase addWidgetToDesktop(String appName, String widgetName);
+}

--- a/src/main/java/koval/mobile/myfitnesspal/gui/ios/downMenuPages/DashboardPage.java
+++ b/src/main/java/koval/mobile/myfitnesspal/gui/ios/downMenuPages/DashboardPage.java
@@ -18,6 +18,7 @@ public class DashboardPage extends DashboardPageBase {
         super(driver);
     }
 
+
     @Override
     public AbstractPage openPageFromDownMenuByName(DownMenuElement downMenuElement) {
         throw new NotImplementedException();

--- a/src/main/java/koval/mobile/myfitnesspal/gui/ios/phoneInterface/PhoneHomePage.java
+++ b/src/main/java/koval/mobile/myfitnesspal/gui/ios/phoneInterface/PhoneHomePage.java
@@ -1,0 +1,61 @@
+package koval.mobile.myfitnesspal.gui.ios.phoneInterface;
+
+
+import com.qaprosoft.carina.core.foundation.webdriver.decorator.ExtendedWebElement;
+import com.qaprosoft.carina.core.gui.AbstractPage;
+import com.zebrunner.carina.utils.exception.NotImplementedException;
+import com.zebrunner.carina.utils.factory.DeviceType;
+import koval.mobile.myfitnesspal.gui.common.phoneInterface.PhoneHomePageBase;
+import koval.mobile.myfitnesspal.gui.common.phoneInterface.PhoneWidgetPageBase;
+import koval.mobile.myfitnesspal.gui.common.searchFood.SearchFoodPageBase;
+import org.openqa.selenium.WebDriver;
+
+
+@DeviceType(pageType = DeviceType.Type.IOS_PHONE, parentClass = PhoneHomePageBase.class)
+public class PhoneHomePage extends PhoneHomePageBase {
+
+
+    public PhoneHomePage(WebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public AbstractPage holdPhoneDesktop() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public PhoneHomePageBase holdWidget(ExtendedWebElement widget) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public boolean isSearchButtonPresent(int timeout) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public boolean isFitnessPalWidgetPresent(int timeout) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public SearchFoodPageBase pressSearchButton() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public PhoneWidgetPageBase tapWidgetButton() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public PhoneHomePageBase deleteWidget(String widgetName) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public PhoneHomePageBase resizeWidgetByX(int sizeValue) {
+        throw new NotImplementedException();
+    }
+}

--- a/src/main/java/koval/mobile/myfitnesspal/gui/ios/phoneInterface/PhoneWidgetPage.java
+++ b/src/main/java/koval/mobile/myfitnesspal/gui/ios/phoneInterface/PhoneWidgetPage.java
@@ -1,0 +1,27 @@
+package koval.mobile.myfitnesspal.gui.ios.phoneInterface;
+
+
+import com.zebrunner.carina.utils.exception.NotImplementedException;
+import com.zebrunner.carina.utils.factory.DeviceType;
+import koval.mobile.myfitnesspal.gui.common.phoneInterface.PhoneHomePageBase;
+import koval.mobile.myfitnesspal.gui.common.phoneInterface.PhoneWidgetPageBase;
+import org.openqa.selenium.WebDriver;
+
+
+@DeviceType(pageType = DeviceType.Type.IOS_PHONE, parentClass = PhoneWidgetPageBase.class)
+public class PhoneWidgetPage extends PhoneWidgetPageBase {
+
+    public PhoneWidgetPage(WebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public boolean isPageOpened(int timeout) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public PhoneHomePageBase addWidgetToDesktop(String appName, String widgetName) {
+        throw new NotImplementedException();
+    }
+}

--- a/src/main/java/koval/mobile/myfitnesspal/service/AdbService.java
+++ b/src/main/java/koval/mobile/myfitnesspal/service/AdbService.java
@@ -1,6 +1,7 @@
 package koval.mobile.myfitnesspal.service;
 
 import com.zebrunner.carina.utils.android.AndroidService;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -8,16 +9,18 @@ import java.lang.invoke.MethodHandles;
 
 
 import static com.zebrunner.carina.utils.common.CommonUtils.pause;
-import static koval.mobile.myfit.service.interfaces.IConstantUtils.TIMEOUT_FIVE;
+import static koval.mobile.myfitnesspal.utils.IConstantUtils.*;
+
 
 public class AdbService extends AndroidService {
 
-    public enum AppPackage{
+    public enum AppPackage {
         MY_FITNESS_PAL("com.myfitnesspal.android"),
         GOOGLE_FIT("com.google.android.apps.fitness"),
         CARINA_DEMO("com.solvd.carinademoapplication");
 
         public final String appPackage;
+
         AppPackage(String appPackage) {
             this.appPackage = appPackage;
         }
@@ -33,7 +36,7 @@ public class AdbService extends AndroidService {
 
     public void clearAppCache(AppPackage packageName) {
         LOGGER.info("Clear ['{}'] cache via ADB", packageName);
-        String[] command = { "adb", "-s", getDevice(getDriver()).getUdid(), "shell", "pm", "clear", packageName.getPackageName() };
+        String[] command = {"adb", "-s", getDevice(getDriver()).getUdid(), "shell", "pm", "clear", packageName.getPackageName()};
         getDevice(getDriver()).execute(command);
     }
 
@@ -44,10 +47,42 @@ public class AdbService extends AndroidService {
         pause(TIMEOUT_FIVE);
     }
 
+    public void closeApp(AppPackage packageName) {
+        LOGGER.info("Closing app ['{}'] via ADB", packageName);
+        String cmd = String.format("shell am force-stop %s", packageName.getPackageName());
+        executor.executeAdbCommand(cmd);
+        pause(TIMEOUT_FIVE);
+    }
+
+    public void holdElementByCoordinates(int centerX, int centerY) {
+        LOGGER.info("Hold element via ADB.(long press) Center y: ['{}'] Center y: ['{}']", centerX, centerY);
+        String cmd = String.format("shell input touchscreen swipe %s %s %s %s 700", centerX, centerY, centerX, centerY);
+        executor.executeAdbCommand(cmd);
+        pause(TIMEOUT_FIVE);
+    }
+
+
+    public int getScreenPhysicalDensity() {
+        LOGGER.info("Get screen physical density via ADB");
+        String cmd = "shell wm density";
+        int physicalDensity = Integer.parseInt(executor.executeAdbCommand(cmd).replaceAll(NUMBERS_ONLY, EMPTY_FIELD));
+        pause(TIMEOUT_FIVE);
+        return physicalDensity;
+    }
+
+
+    public boolean isKeyBoardOpen() {
+        LOGGER.info("Check if keyboard is open via ADB");
+        String cmd = "shell dumpsys input_method | grep mInputShown";
+        boolean isKeyBoardOpenValue = Boolean.parseBoolean(String.valueOf(executor.executeAdbCommand(cmd).contains("true")));
+        LOGGER.info("KeyBoard is open: {}", isKeyBoardOpenValue);
+        pause(TIMEOUT_FIVE);
+        return isKeyBoardOpenValue;
+    }
+
 
     public void setDarkMode(String yesNo) {
         LOGGER.info("Set Dark Mode: " + yesNo);
-
         String cmd = String.format("shell cmd uimode night %s", yesNo);
         executor.executeAdbCommand(cmd);
         pause(TIMEOUT_FIVE);

--- a/src/main/java/koval/mobile/myfitnesspal/utils/IConstantUtils.java
+++ b/src/main/java/koval/mobile/myfitnesspal/utils/IConstantUtils.java
@@ -126,6 +126,8 @@ public interface IConstantUtils {
 
     String DIARY_TEXT = "Diary";
 
+    String SNACKS = "Snacks";
+
     String DO_NOT_ASK_ME_AGAIN = "Don''t ask me again";
 
     String EXERCISE_STRING = "Exercise";

--- a/src/main/java/koval/mobile/myfitnesspal/utils/IConstantUtils.java
+++ b/src/main/java/koval/mobile/myfitnesspal/utils/IConstantUtils.java
@@ -4,6 +4,8 @@ package koval.mobile.myfitnesspal.utils;
 import java.util.Arrays;
 import java.util.List;
 
+import static koval.mobile.myfitnesspal.gui.IMyInterface.adbService;
+
 public interface IConstantUtils {
 
     int ONE_TIME = 1;
@@ -32,11 +34,17 @@ public interface IConstantUtils {
 
     int TWENTY_COUNT = 20;
 
-    int MEDIUM_SPEED = 600;
+    int MEDIUM_SPEED = 1000;
 
-    int LOW_SPEED = 4500;
+    int LOW_SPEED = 7000;
+
+    int HOME_PAGE = 3;
+
+    int BACK = 4;
 
     String SPACE_FIELD = " ";
+
+    String EMPTY_FIELD = "";
 
     String ONE_VALUE = "one";
 
@@ -66,6 +74,8 @@ public interface IConstantUtils {
 
     String NO_THANKS_ANSWER = "No Thanks";
 
+    String NUMBERS_ONLY = "[^0-9]";
+
     String SAVE = "Save";
 
     String ACCEPT = "Accept";
@@ -73,6 +83,8 @@ public interface IConstantUtils {
     String CHECKED = "checked";
 
     String LOGIN = "Log In";
+
+    String LOADING = "Loading…";
 
     String SIGNUP = "Sign Up";
 
@@ -102,7 +114,11 @@ public interface IConstantUtils {
 
     String HEIGHT = "height";
 
+    String HOME_STRING = "Home";
+
     String WEEKLY_GOAL = "Weekly Goal";
+
+    String WIDGETS_STRING = "Widgets";
 
     String CURRENT_WEIGHT = "current_weight";
 
@@ -116,6 +132,12 @@ public interface IConstantUtils {
 
     String UNITS_VALUE = "units";
 
+    String FITNESSPAL= "MyFitnessPal";
+
+    String CALORIES_WIDGET = "Calories";
+
     List<String> MY_FOOD = Arrays.asList("Milk with honey", "Apple with sugar", "Bread and Butter", "Water with honey");
+
+    int SCREEN_PHYSICAL_DENSITY = adbService.getScreenPhysicalDensity();
 
 }

--- a/src/main/java/koval/mobile/myfitnesspal/utils/IConstantUtils.java
+++ b/src/main/java/koval/mobile/myfitnesspal/utils/IConstantUtils.java
@@ -136,6 +136,8 @@ public interface IConstantUtils {
 
     String CALORIES_WIDGET = "Calories";
 
+    String CONNECT_A_STEP_TRACKER = "Connect a step tracker";
+
     List<String> MY_FOOD = Arrays.asList("Milk with honey", "Apple with sugar", "Bread and Butter", "Water with honey");
 
     int SCREEN_PHYSICAL_DENSITY = adbService.getScreenPhysicalDensity();

--- a/src/test/java/koval/myfitnesspal/login/FitnessPalTest.java
+++ b/src/test/java/koval/myfitnesspal/login/FitnessPalTest.java
@@ -3,6 +3,9 @@ package koval.myfitnesspal.login;
 import com.zebrunner.agent.core.annotation.TestLabel;
 import com.zebrunner.carina.core.registrar.ownership.MethodOwner;
 
+import koval.mobile.myfitnesspal.gui.MyAbstractPage;
+import koval.mobile.myfitnesspal.gui.common.phoneInterface.PhoneHomePageBase;
+import koval.mobile.myfitnesspal.gui.common.phoneInterface.PhoneWidgetPageBase;
 import koval.mobile.myfitnesspal.gui.common.searchFood.SearchFoodPageBase;
 import koval.mobile.myfitnesspal.gui.common.downMenuPages.DashboardPageBase;
 import koval.mobile.myfitnesspal.gui.common.downMenuPages.DiaryPageBase;
@@ -23,6 +26,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.lang.invoke.MethodHandles;
+import java.security.Key;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
@@ -34,11 +38,16 @@ public class FitnessPalTest extends LoginTest {
 
     private static final List<String> FOOD = Arrays.asList("Apple", "Bread", "Water", "Cherries");
 
-    final static int FOOD_MEAL_INDEX = new Random().nextInt(FOOD.size());
+    private static final int FOOD_MEAL_INDEX = new Random().nextInt(FOOD.size());
 
-    final static String MEAL_NAME = "meal_" + new Random().nextInt(100) + 1;
+    private static final String MEAL_NAME = "meal_" + new Random().nextInt(100) + 1;
 
-    @Test()
+    private static final int SIZE_VALUE_BY_X = 2;
+
+
+    MyAbstractPage abstractPage;
+
+    @Test(groups = {"logoutWithCashClear"})
     @MethodOwner(owner = "koval")
     @TestLabel(name = "feature", value = {"mobile", "regression"})
     public void loginSimpleUserTest() {
@@ -49,7 +58,7 @@ public class FitnessPalTest extends LoginTest {
     }
 
 
-    @Test()
+    @Test(groups = {"logoutWithCashClear"})
     @MethodOwner(owner = "koval")
     @TestLabel(name = "feature", value = {"mobile", "regression"})
     public void addFoodTest() {
@@ -63,6 +72,7 @@ public class FitnessPalTest extends LoginTest {
         diaryPageBase.closePromoMessagesIfPresent();
 
         Meals[] mealsArr = Meals.values();
+
 
         for (int i = 0; i < Meals.values().length; i++) {
 
@@ -87,7 +97,7 @@ public class FitnessPalTest extends LoginTest {
         }
     }
 
-    @Test()
+    @Test(groups = {"logoutWithCashClear"})
     @MethodOwner(owner = "koval")
     @TestLabel(name = "feature", value = {"mobile", "regression"})
     public void addCreatedOwnFoodToBreakfastTest() {
@@ -162,4 +172,35 @@ public class FitnessPalTest extends LoginTest {
     }
 
 
+    @Test(groups = {"logoutWithoutCashClear"})
+    @MethodOwner(owner = "dkoval")
+    @TestLabel(name = "feature", value = {"mobile", "regression"})
+    public void searchButtonFromWidgetTest() {
+
+        DashboardPageBase dashboardPageBase = initPage(getDriver(), DashboardPageBase.class);
+        dashboardPageBase.pressKey(HOME_PAGE);
+
+
+        PhoneHomePageBase phoneHomePageBase = initPage(getDriver(), PhoneHomePageBase.class);
+        phoneHomePageBase.holdPhoneDesktop();
+
+
+        PhoneWidgetPageBase phoneWidgetPageBase = phoneHomePageBase.tapWidgetButton();
+        Assert.assertTrue(phoneWidgetPageBase.isPageOpened(), "[ WIDGET PAGE ] Widget page is not opened!");
+
+        phoneWidgetPageBase.addWidgetToDesktop(FITNESSPAL, CALORIES_WIDGET);
+        Assert.assertTrue(phoneHomePageBase.isFitnessPalWidgetPresent(TIMEOUT_FIFTEEN),
+                String.format("[ PHONE HOME PAGE ] '%s' widget is not added! App name '%s'", FITNESSPAL, CALORIES_WIDGET));
+
+        phoneHomePageBase.resizeWidgetByX(SIZE_VALUE_BY_X);
+
+        Assert.assertTrue(phoneHomePageBase.isSearchButtonPresent(TIMEOUT_FIFTEEN),
+                "[ PHONE HOME PAGE ] Search Button is not present in the widget!");
+
+
+        SearchFoodPageBase searchFoodPageBase = phoneHomePageBase.pressSearchButton();
+        Assert.assertTrue(searchFoodPageBase.isPageOpened(), "[ SEARCH FOOD PAGE ] Search Food page is not opened!");
+        Assert.assertTrue(adbService.isKeyBoardOpen(), "[ SEARCH FOOD PAGE ] KeyBoard is not opened!");
+
+    }
 }

--- a/src/test/java/koval/myfitnesspal/login/FitnessPalTest.java
+++ b/src/test/java/koval/myfitnesspal/login/FitnessPalTest.java
@@ -26,7 +26,6 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.lang.invoke.MethodHandles;
-import java.security.Key;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;

--- a/src/test/java/koval/myfitnesspal/login/LoginTest.java
+++ b/src/test/java/koval/myfitnesspal/login/LoginTest.java
@@ -2,14 +2,12 @@ package koval.myfitnesspal.login;
 
 
 import com.zebrunner.carina.utils.R;
-import koval.mobile.myfitnesspal.gui.MyAbstractPage;
 import koval.mobile.myfitnesspal.gui.common.downMenuPages.DashboardPageBase;
 import koval.mobile.myfitnesspal.gui.common.loginPages.LogInPageBase;
 import koval.mobile.myfitnesspal.gui.IMyInterface;
 import koval.mobile.myfitnesspal.gui.common.loginPages.WelcomePageBase;
 import koval.mobile.myfitnesspal.gui.common.phoneInterface.PhoneHomePageBase;
 import koval.mobile.myfitnesspal.service.AdbService;
-import org.openqa.selenium.WebDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;

--- a/src/test/java/koval/myfitnesspal/login/LoginTest.java
+++ b/src/test/java/koval/myfitnesspal/login/LoginTest.java
@@ -68,7 +68,7 @@ public class LoginTest implements IMyInterface {
 
         phoneHomePageBase.deleteWidget(FITNESSPAL);
 
-        Assert.assertFalse(phoneHomePageBase.isFitnessPalWidgetPresent(TIMEOUT_FIFTEEN),
+        Assert.assertTrue(phoneHomePageBase.isFitnessPalWidgetPresent(TIMEOUT_FIFTEEN),
                 String.format("[ PHONE HOME PAGE ] '%s' widget is not deleted! App name '%s'", FITNESSPAL, CALORIES_WIDGET));
 
     }

--- a/src/test/java/koval/myfitnesspal/login/LoginTest.java
+++ b/src/test/java/koval/myfitnesspal/login/LoginTest.java
@@ -7,6 +7,7 @@ import koval.mobile.myfitnesspal.gui.common.downMenuPages.DashboardPageBase;
 import koval.mobile.myfitnesspal.gui.common.loginPages.LogInPageBase;
 import koval.mobile.myfitnesspal.gui.IMyInterface;
 import koval.mobile.myfitnesspal.gui.common.loginPages.WelcomePageBase;
+import koval.mobile.myfitnesspal.gui.common.phoneInterface.PhoneHomePageBase;
 import koval.mobile.myfitnesspal.service.AdbService;
 import org.openqa.selenium.WebDriver;
 import org.slf4j.Logger;
@@ -21,7 +22,6 @@ public class LoginTest implements IMyInterface {
 
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-    AdbService adbService = new AdbService();
 
 
 
@@ -55,9 +55,23 @@ public class LoginTest implements IMyInterface {
 
     }
 
-    @AfterMethod
-    public void logout() {
+    @AfterMethod(onlyForGroups = {"logoutWithCashClear"})
+    public void clearCashAndLogout() {
         adbService.clearAppCache(AdbService.AppPackage.MY_FITNESS_PAL);
+
     }
 
+
+    @AfterMethod(onlyForGroups = {"logoutWithoutCashClear"})
+    public void logout() {
+        adbService.closeApp(AdbService.AppPackage.MY_FITNESS_PAL);
+
+        PhoneHomePageBase phoneHomePageBase = initPage(getDriver(), PhoneHomePageBase.class);
+
+        phoneHomePageBase.deleteWidget(FITNESSPAL);
+
+        Assert.assertFalse(phoneHomePageBase.isFitnessPalWidgetPresent(TIMEOUT_FIFTEEN),
+                String.format("[ PHONE HOME PAGE ] '%s' widget is not deleted! App name '%s'", FITNESSPAL, CALORIES_WIDGET));
+
+    }
 }


### PR DESCRIPTION
Hold phone desktop.
Tap “Widgets” and Tap “MyFitnesspal”.
Choose “Calories Consumed” widget and Add widget to the desktop.
Hold widget and resize widget to 2x2.
Tap “Search” icon.






A 2x2 widget has a “Search” button that opens the app to the food search screen with keyboard engaged.